### PR TITLE
Add project editing and deletion

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -26,19 +26,23 @@ module.exports.isAdminAuthenticated = (req, res, next) => {
   }
 }
 
-module.exports.upload = (id) => ( 
-  async (req, res, next) => {
-    const impl = upload.single(id);
-    impl(req, res, async (err) => {
-        if (err instanceof multer.MulterError) {
-          req.flash('error', 'Please upload a valid image. Only JPEG, JPG, and PNG files are allowed, and they must be under 5MB.');
-          res.redirect(req.url);
-        } else if (err) {
-          req.flash('error', 'An error occurred while trying to upload your image! Please try again. If the issue persists, contact us.');
-          res.redirect(req.url);
-        } else {
-          next();
-        }
-    })
+module.exports.upload = function (id, required = true) { 
+  const impl = upload.single(id);
+  return async (req, res, next) => {
+    if (required || req.body[id]) {
+      impl(req, res, async (err) => {
+          if (err instanceof multer.MulterError) {
+            req.flash('error', 'Please upload a valid image. Only JPEG, JPG, and PNG files are allowed, and they must be under 5MB.');
+            res.redirect(req.url);
+          } else if (err) {
+            req.flash('error', 'An error occurred while trying to upload your image! Please try again. If the issue persists, contact us.');
+            res.redirect(req.url);
+          } else {
+            next();
+          }
+      });
+    } else {
+      next();
+    }
   }
-)
+}

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const db = require('../database/db');
+const fs = require('fs')
 const { isAdminAuthenticated, upload } = require('../middleware');
 const router = express.Router();
+
+const getDBArchivedValue = (req) => (req.body.archived !== undefined).toString()
 
 router.get('/projects', async (req, res) => {
   const resp = await db.query("SELECT * FROM projects ORDER BY archived, title");
@@ -12,8 +15,31 @@ router.post('/projects', isAdminAuthenticated, upload('image'), async (req, res)
   await db.query(
     "INSERT INTO projects VALUES ($1, $2, $3, $4, $5, $6, $7)",
     [uuid.v4(), req.body.title, req.body.description, req.body.website, req.body.repository, 
-      (req.body.archived !== undefined).toString(), req.file.filename]);
+      getDBArchivedValue(req), req.file.filename]);
   req.flash('success', 'Successfully added project!');
+  res.redirect('/projects');
+});
+
+router.post('/projects/edit', isAdminAuthenticated, upload('image', true), async (req, res) => {
+  // Image uploading is optional when editing projects, so we need to perform different queries
+  // for the different states.
+  if (req.file) {
+      // Free the space taken up by the now-unused project image. This requires us to obtain
+      // the original image ID from the database.
+      let resp = await db.query("SELECT image_id FROM projects WHERE id = $1", [req.body.id]);
+      fs.unlinkSync("uploads/" + resp.rows[0].image_id);
+      await db.query(
+        "UPDATE projects SET title = $1, description = $2, website = $3, repository = $4, archived = $5, image_id = $6 WHERE id = $7",
+        [req.body.title, req.body.description, req.body.website, req.body.repository, 
+          getDBArchivedValue(req), req.file.filename, req.body.id])
+  } else {
+    // No image specified, leave it unchanged and only commit the rest.
+    await db.query(
+      "UPDATE projects SET title = $1, description = $2, website = $3, repository = $4, archived = $5 WHERE id = $6",
+      [req.body.title, req.body.description, req.body.website, req.body.repository, 
+        getDBArchivedValue(req), req.body.id])
+  }
+  req.flash('success', 'Successfully updated project!');
   res.redirect('/projects');
 });
 

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const db = require('../database/db');
-const fs = require('fs')
+const fs = require('fs');
+const uuid = require('uuid');
 const { isAdminAuthenticated, upload } = require('../middleware');
 const router = express.Router();
 

--- a/views/projects.ejs
+++ b/views/projects.ejs
@@ -33,8 +33,8 @@
                             <label class="d-block py-1" for="website">Website Link</label>
                             <input id="website" name="website" type="url" />
          
-                            <label class="d-block py-1" for="authors">Authors</label>
-                            <input id="authors" name="authors" type="text" required />
+   <!--                          <label class="d-block py-1" for="authors">Authors</label>
+                            <input id="authors" name="authors" type="text" required /> -->
          
                             <label class="d-block py-1" for="archived">Archived</label>
                             <input id="archived" name="archived" type="checkbox" />
@@ -59,7 +59,6 @@
                 <div class="col">
                     <h2 class="project-title">
                         <%= project.title %>
-                        <!-- TODO: Make a style for this-->
                         <% if (project.archived) { %>
                             <span class="project-archived">(Inactive)</span>
                         <% } %>
@@ -71,6 +70,58 @@
                         <% } %>
                         <a class="d-block"  href="<%= project.repository %>">Repository</a>
                     </div>
+                    <% if (typeof user == 'object' && user && user.is_admin) { %>
+                        <button type="button" class="btn btn-primary d-block mt-2" data-bs-toggle="modal" data-bs-target="#editProject<%= project.id %>Modal">
+                            Edit Project
+                        </button>
+                        
+                        <!-- Modal -->
+                        <div class="modal fade" id="editProject<%= project.id %>Modal" tabindex="-1" aria-labelledby="editProject<%= project.id %>ModalLabel" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title" id="editProject<%= project.id %>ModalLabel">Project Details</h5>
+                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                    </div>
+                                    <form method="POST" action="/projects/edit" enctype="multipart/form-data" >
+                                        <div class="modal-body">
+                                            <input type="hidden" name="id" value="<%= project.id %>">
+
+                                            <label class="d-block py-1" for="title">Title</label>
+                                            <input id="title" name="title" type="text" required value="<%= project.title %>" />
+                                            
+                                            <label class="d-block py-1" for="description">Description</label>
+                                            <input id="description" name="description" type="text" required value="<%= project.description %>" />
+                         
+                                            <label class="d-block py-1" for="repository">Repository Link</label>
+                                            <input id="repository" name="repository" type="url" required value="<%= project.repository %>" />
+                         
+                                            <label class="d-block py-1" for="website">Website Link</label>
+                                            <input id="website" name="website" type="url" required value="<%= project.website %>" />
+                         
+<!--                                             <label class="d-block py-1" for="authors">Authors</label>
+                                            <input id="authors" name="authors" type="text" required />
+                          -->
+                                            <label class="d-block py-1" for="archived">Archived</label>
+                                            <% if (project.archived) { %>
+                                                <input id="archived" name="archived" type="checkbox" checked>
+                                            <% } else { %>
+                                                <input id="archived" name="archived" type="checkbox">
+                                            <% } %>
+                         
+                                            <label class="d-block py-1" for="image">Image</label>
+                                            <input id="image" name="image" type="file" accept="image/png,image/jpg,image/jpeg" />
+                                            <p>Images must be under 5 MB and of JPG/JPEG/PNG type.</p>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
+                                            <button type="submit" class="btn btn-primary">Save</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    <% } %>
                 </div>
                 <% if(project.image_id) { %>
                     <img src="uploads/<%= project.image_id %>" class="project-image" />

--- a/views/projects.ejs
+++ b/views/projects.ejs
@@ -16,7 +16,7 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="newProjectModalLabel">Project Details</h5>
+                        <h5 class="modal-title" id="newProjectModalLabel">New Project</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <form method="POST" action="/projects" enctype="multipart/form-data" >
@@ -80,7 +80,7 @@
                             <div class="modal-dialog">
                                 <div class="modal-content">
                                     <div class="modal-header">
-                                        <h5 class="modal-title" id="editProject<%= project.id %>ModalLabel">Project Details</h5>
+                                        <h5 class="modal-title" id="editProject<%= project.id %>ModalLabel">Edit Project</h5>
                                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                     </div>
                                     <form method="POST" action="/projects/edit" enctype="multipart/form-data" >

--- a/views/projects.ejs
+++ b/views/projects.ejs
@@ -5,18 +5,16 @@
     <p>Projects are a great way to get involved with Mines ACM! Apply existing knowledge
         and learn new skills with our variety of projects.</p>
 
-    <!-- Button trigger modal -->
     <% if (typeof user == 'object' && user && user.is_admin) { %>
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#newProjectModal">
+        <button type="button" class="btn btn-primary mt-2" data-bs-toggle="modal" data-bs-target="#newProjectModal">
             New Project
         </button>
         
-        <!-- Modal -->
         <div class="modal fade" id="newProjectModal" tabindex="-1" aria-labelledby="newProjectModalLabel" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="newProjectModalLabel">New Project</h5>
+                        <h5 class="modal-title" id="newProjectModalLabel">New </h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <form method="POST" action="/projects" enctype="multipart/form-data" >
@@ -71,11 +69,36 @@
                         <a class="d-block"  href="<%= project.repository %>">Repository</a>
                     </div>
                     <% if (typeof user == 'object' && user && user.is_admin) { %>
-                        <button type="button" class="btn btn-primary d-block mt-2" data-bs-toggle="modal" data-bs-target="#editProject<%= project.id %>Modal">
-                            Edit Project
-                        </button>
+                        <div class="d-block mt-2">
+                            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#editProject<%= project.id %>Modal">
+                                Edit Project
+                            </button>
+                            <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteProject<%= project.id %>Modal">
+                                Delete Project
+                            </button>
+                        </div>
                         
-                        <!-- Modal -->
+                        <div class="modal fade" id="deleteProject<%= project.id %>Modal" tabindex="-1" aria-labelledby="deleteProject<%= project.id %>ModalLabel" aria-hidden="true">
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title" id="deleteProject<%= project.id %>ModalLabel">Delete Project</h5>
+                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                    </div>
+                                    <form method="POST" action="/projects/delete">
+                                        <div class="modal-body">
+                                            <p>Are you sure you want to delete the <strong><%= project.title %></strong> project?</p>
+                                            <input type="hidden" name="id" value="<%= project.id %>">
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="submit" class="btn btn-danger">Yes</button>
+                                            <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+
                         <div class="modal fade" id="editProject<%= project.id %>Modal" tabindex="-1" aria-labelledby="editProject<%= project.id %>ModalLabel" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -114,12 +137,13 @@
                                             <p>Images must be under 5 MB and of JPG/JPEG/PNG type.</p>
                                         </div>
                                         <div class="modal-footer">
-                                            <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
                                             <button type="submit" class="btn btn-primary">Save</button>
+                                            <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
                                         </div>
                                     </form>
                                 </div>
-                            </div>
+                            </div>                       
+
                         </div>
                     <% } %>
                 </div>

--- a/views/projects.ejs
+++ b/views/projects.ejs
@@ -44,7 +44,7 @@
                             <p>Images must be under 5 MB and of JPG/JPEG/PNG type.</p>
                         </div>
                         <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
+                            <button type="reset" class="btn btn-secondary" data-bs-dismiss="modal">Discard</button>
                             <button type="submit" class="btn btn-primary">Save</button>
                         </div>
                     </form>


### PR DESCRIPTION
Adds project editing functionality (and also a few tweaks to the project UI itself).

- When in admin mode, all projects now have an 'edit' button that launches a project-specific
modal containing the current values (in an editable state).
- Edited values are POSTed to `projects/edit`, and are always committed to the database regardless of change status (preventing useless edits would require frontend JS unless we went for an weird flash flow)
- Image uploading is optional in editing dialogs, as there's no way to prepopulate the image in a user-friendly way. A missing image upload is thus interpreted as a desire to not change the image. The upload middleware has been updated to handle this.
- The author field has been removed from the modals until they can be properly implemented in the `project-authors` branch.
- The project modals are now specifically named "New project" and "Edit project" to differentiate between them.
