### PR TITLE
Make error stack-trace full-width

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -210,11 +210,6 @@ p {
     overflow: scroll;
 }
 
-.error-scroll {
-    width: 100%;
-    height: 50vh;
-}
-
 .acm-blue {
     color: #0083c5;
 }

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -210,6 +210,11 @@ p {
     overflow: scroll;
 }
 
+.error-scroll {
+    width: 100%;
+    height: 50vh;
+}
+
 .acm-blue {
     color: #0083c5;
 }

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -5,5 +5,5 @@
 	<p>Sorry - Something broke on our end!</p>
 
 	<p>Stacktrace:</p>
-	<textarea><%= error %></textarea>
+	<textarea class="error-scroll"><%= error %></textarea>
 </div>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -5,5 +5,5 @@
 	<p>Sorry - Something broke on our end!</p>
 
 	<p>Stacktrace:</p>
-	<textarea class="error-scroll"><%= error %></textarea>
+	<textarea style="width: 100%; height: 50vh"><%= error %></textarea>
 </div>


### PR DESCRIPTION
I was having issues debugging with such a small textarea, so I decided to extend it to roughly the screen size like other scrolling elements.