### PR TITLE
Ical Integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ const adminRoutes = require('./routes/admin');
 const profileRoutes = require('./routes/profile');
 const projectsRoutes = require('./routes/projects');
 const presentationsRoutes = require('./routes/presentations');
+const scheduleRoutes = require('./routes/schedule');
 const app = express();
 
 app.engine('ejs', ejsMate);
@@ -93,6 +94,7 @@ app.use('/', authRoutes);
 app.use('/', presentationsRoutes);
 app.use('/', profileRoutes);
 app.use('/', projectsRoutes);
+app.use('/', scheduleRoutes);
 
 app.get('/', async (req, res) => {
   const resp = await db.query("SELECT * FROM images ORDER BY RANDOM() LIMIT 1");
@@ -117,24 +119,6 @@ app.get('/', async (req, res) => {
 app.get('/about', async (req, res) => {
   const resp = await db.query("SELECT * FROM users WHERE title != ''");
   res.render('about', { title: 'About Us', people: resp.rows });
-});
-
-app.get('/schedule', async (req, res) => {
-  let upcoming = await db.query("SELECT * FROM meetings WHERE date >= NOW() AND date <= NOW() + INTERVAL '3 weeks' ORDER BY date");
-  for (let meeting in upcoming.rows) {
-    if (req.user) {
-      const rsvp = await db.query("SELECT * FROM rsvps WHERE email = $1 AND meeting = $2", [req.user.email, upcoming.rows[meeting].id]);
-      if (rsvp.rows.length > 0) {
-        upcoming.rows[meeting].rsvped = true;
-      }
-    }
-    else {
-      upcoming.rows[meeting].rsvped = false;
-    }
-  }
-
-  let previous = await db.query("SELECT * FROM meetings WHERE date <= NOW() ORDER BY date DESC");
-  res.render('schedule', { title: 'Schedule', upcoming: upcoming.rows, previous: previous.rows });
 });
 
 app.get('/uploads/:id', (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "helmet": "^7.0.0",
+        "ical-generator": "^5.0.0",
         "multer": "^1.4.5-lts.1",
         "passport": "^0.6.0",
         "passport-google-oauth2": "^0.2.0",
@@ -635,6 +636,57 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/ical-generator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-5.0.0.tgz",
+      "integrity": "sha512-o0klZ3J0IOAD5VitK2bNVBPSrSPEe+uglCk9zBa2MSYbKxPvjWlHjbaZaNWWC8MOqpkNBF+viteFExyjt1S5XQ==",
+      "dependencies": {
+        "uuid-random": "^1.3.2"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@touch4it/ical-timezones": ">=1.6.0",
+        "@types/luxon": ">= 1.26.0",
+        "@types/mocha": ">= 8.2.1",
+        "@types/node": ">= 15.0.0",
+        "dayjs": ">= 1.10.0",
+        "luxon": ">= 1.26.0",
+        "moment": ">= 2.29.0",
+        "moment-timezone": ">= 0.5.33",
+        "rrule": ">= 2.6.8"
+      },
+      "peerDependenciesMeta": {
+        "@touch4it/ical-timezones": {
+          "optional": true
+        },
+        "@types/luxon": {
+          "optional": true
+        },
+        "@types/mocha": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-timezone": {
+          "optional": true
+        },
+        "rrule": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -1327,6 +1379,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1815,6 +1872,14 @@
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      }
+    },
+    "ical-generator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-5.0.0.tgz",
+      "integrity": "sha512-o0klZ3J0IOAD5VitK2bNVBPSrSPEe+uglCk9zBa2MSYbKxPvjWlHjbaZaNWWC8MOqpkNBF+viteFExyjt1S5XQ==",
+      "requires": {
+        "uuid-random": "^1.3.2"
       }
     },
     "iconv-lite": {
@@ -2328,6 +2393,11 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+    },
+    "uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "helmet": "^7.0.0",
+    "ical-generator": "^5.0.0",
     "multer": "^1.4.5-lts.1",
     "passport": "^0.6.0",
     "passport-google-oauth2": "^0.2.0",

--- a/routes/schedule.js
+++ b/routes/schedule.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const db = require('../database/db');
+const ical = require('ical-generator');
 const router = express.Router();
 
 router.get('/schedule', async (req, res) => {
@@ -18,6 +19,34 @@ router.get('/schedule', async (req, res) => {
 
   let previous = await db.query("SELECT * FROM meetings WHERE date <= NOW() ORDER BY date DESC");
   res.render('schedule', { title: 'Schedule', upcoming: upcoming.rows, previous: previous.rows });
+});
+
+router.get('/schedule/ical.ics', async (req, res) => {
+  const resp = await db.query("SELECT * FROM meetings");
+
+  const calendar = ical.default({ 
+    name: 'Mines ACM',
+    description: "All of the talks\\, open source meetings\\, and other activities of the Mines ACM Student Chapter.",
+    prodId: {
+      company: 'Mines ACM',
+      product: 'web',
+      language: 'EN'
+    }
+  });
+
+  for (let meeting of resp.rows) {
+    calendar.createEvent({
+      id: meeting.id,
+      summary: meeting.title,
+      description: meeting.description,
+      location: meeting.location,
+      start: meeting.date,
+      timezone: 'America/Denver',
+      end: new Date(meeting.date.getTime() + meeting.duration)
+    })
+  }
+
+  calendar.serve(res);
 });
 
 module.exports = router;

--- a/routes/schedule.js
+++ b/routes/schedule.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const db = require('../database/db');
+const router = express.Router();
+
+router.get('/schedule', async (req, res) => {
+  let upcoming = await db.query("SELECT * FROM meetings WHERE date >= NOW() AND date <= NOW() + INTERVAL '3 weeks' ORDER BY date");
+  for (let meeting in upcoming.rows) {
+    if (req.user) {
+      const rsvp = await db.query("SELECT * FROM rsvps WHERE email = $1 AND meeting = $2", [req.user.email, upcoming.rows[meeting].id]);
+      if (rsvp.rows.length > 0) {
+        upcoming.rows[meeting].rsvped = true;
+      }
+    }
+    else {
+      upcoming.rows[meeting].rsvped = false;
+    }
+  }
+
+  let previous = await db.query("SELECT * FROM meetings WHERE date <= NOW() ORDER BY date DESC");
+  res.render('schedule', { title: 'Schedule', upcoming: upcoming.rows, previous: previous.rows });
+});
+
+module.exports = router;


### PR DESCRIPTION
Add a route to `/schedules` that generates an iCal file containing all past and future meetings. Testing with google calendar fields good results.

This could hypothetically be optimized in the future, but for now we want to retain behavior consistency with the old site.