### PR TITLE
Improve error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,6 @@ const profileRoutes = require('./routes/profile');
 const projectsRoutes = require('./routes/projects');
 const presentationsRoutes = require('./routes/presentations');
 const scheduleRoutes = require('./routes/schedule');
-const { URL } = require("url");
 const app = express();
 
 app.engine('ejs', ejsMate);

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ const profileRoutes = require('./routes/profile');
 const projectsRoutes = require('./routes/projects');
 const presentationsRoutes = require('./routes/presentations');
 const scheduleRoutes = require('./routes/schedule');
+const { URL } = require("url");
 const app = express();
 
 app.engine('ejs', ejsMate);

--- a/database/db.js
+++ b/database/db.js
@@ -3,6 +3,19 @@ const pg = require('pg');
 const pool = new pg.Pool({ connectionString: process.env.DB_URL });
 
 module.exports = {
+    transaction: async (block) => {
+        const client = await pool.connect();
+        try {
+            await client.query("BEGIN");
+            await block(client);
+            await client.query("COMMIT");
+        } catch (e) {
+            await client.query("ROLLBACK");
+            throw e;
+        } finally {
+            client.release();
+        }
+    },
     query: async (text, params, callback) => {
         return pool.query(text, params, callback);
     },

--- a/middleware.js
+++ b/middleware.js
@@ -27,24 +27,20 @@ module.exports.isAdminAuthenticated = (req, res, next) => {
   }
 }
 
-module.exports.upload = function (id, required = true) {
+module.exports.upload = function (id) {
   const impl = upload.single(id);
   return async (req, res, next) => {
-    if (required || req.body[id]) {
-      impl(req, res, async (err) => {
-        if (err instanceof multer.MulterError) {
-          req.flash('error', 'Please upload a valid image. Only JPEG, JPG, and PNG files are allowed, and they must be under 5MB.');
-          res.redirect(req.url);
-        } else if (err) {
-          req.flash('error', 'An error occurred while trying to upload your image! Please try again. If the issue persists, contact us.');
-          res.redirect(req.url);
-        } else {
-          next();
-        }
-      });
-    } else {
-      next();
-    }
+    impl(req, res, async (err) => {
+      if (err instanceof multer.MulterError) {
+        req.flash('error', 'Please upload a valid image. Only JPEG, JPG, and PNG files are allowed, and they must be under 5MB.');
+        res.redirect(req.url);
+      } else if (err) {
+        req.flash('error', 'An error occurred while trying to upload your image! Please try again. If the issue persists, contact us.');
+        res.redirect(req.url);
+      } else {
+        next();
+      }
+    });
   }
 }
 

--- a/middleware.js
+++ b/middleware.js
@@ -56,7 +56,10 @@ module.exports.fallible = (block) => {
         try {
           fs.unlinkSync("uploads/" + req.file.filename)
         } catch (e) {
-          // Just ignore this.
+          // Letting this error be thrown would crash the server, and
+          // routing it to next would override the original error we
+          // wanted to catch and make debugging more difficult. Thus,
+          // we ignore the error.
         }
       }
       next(e);

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,7 @@
 const multer = require('multer');
 const { multerConfig } = require('./config/general.config');
 const upload = multer(multerConfig);
-const fs = require('fs/promises');
+const fs = require('fs');
 
 module.exports.isLoggedIn = (req, res, next) => {
   if (!req.isAuthenticated()) {
@@ -27,7 +27,7 @@ module.exports.isAdminAuthenticated = (req, res, next) => {
   }
 }
 
-module.exports.upload = function (id) {
+module.exports.upload = (id) => {
   const impl = upload.single(id);
   return async (req, res, next) => {
     impl(req, res, async (err) => {
@@ -54,7 +54,7 @@ module.exports.fallible = (block) => {
       // in the database.
       if (req.file) {
         try {
-          await fs.unlink(req.file.filename)
+          fs.unlinkSync("uploads/" + req.file.filename)
         } catch (e) {
           // Just ignore this.
         }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -63,7 +63,7 @@ router.post('/officers', isAdminAuthenticated, fallible(async (req, res) => {
 }));
 
 router.post('/officers/remove', isAdminAuthenticated, fallible(async (req, res) => {
-  if (typeof req.body.user_id !== "string" || req.body.user_id.length < 0) {
+  if (typeof req.body.user_id !== "string" || req.body.user_id.length < 1) {
     throw new TypeError("Invalid user id")
   }
   const userId = req.body.user_id;
@@ -84,7 +84,7 @@ router.post('/feedback/remove', isAdminAuthenticated, fallible(async (req, res) 
   if (typeof req.body.feedback === "string" && req.body.feedback.length > 0) {
     feedback.feedback = req.body.feedback;
   } else {
-    throw new TypeError("Invalid title");
+    throw new TypeError("Invalid feedback");
   }
 
   await db.query("DELETE FROM feedback WHERE user_id = $1 and feedback = $2", 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,66 +1,172 @@
 const express = require('express');
 const router = express.Router();
 const db = require('../database/db');
-const { isAdminAuthenticated, upload } = require('../middleware');
+const { isAdminAuthenticated, upload, fallible } = require('../middleware');
 const uuid = require('uuid');
 
-router.get('/admin', isAdminAuthenticated, async (req, res) => {
-  let meetings = await db.query("SELECT * FROM meetings ORDER BY date");
-  for (let meeting in meetings.rows) {
-    const attendance = await db.query("SELECT attendance.user_id FROM meetings JOIN attendance ON meetings.id = attendance.meeting WHERE meetings.id = $1", [meetings.rows[meeting].id]);
-    meetings.rows[meeting].attendance = attendance.rows;
+router.get('/admin', isAdminAuthenticated, fallible(async (req, res) => {
+  let meetingsResp = await db.query("SELECT * FROM meetings ORDER BY date");
+  for (let meeting of meetingsResp.rows) {
+    const attendanceResp = await db.query(
+      "SELECT attendance.user_id FROM meetings JOIN attendance ON meetings.id = attendance.meeting WHERE meetings.id = $1", 
+      [meeting.id]);
+    meeting.attendance = attendanceResp.rows;
   }
 
-  const officers = await db.query("SELECT * FROM users WHERE title != ''");
-  const feedback = await db.query("SELECT * FROM feedback");
-  res.render('admin', { title: 'Admin', meetings: meetings.rows, officers: officers.rows, feedbackData: feedback.rows });
-});
+  const officersResp = await db.query("SELECT * FROM users WHERE title != ''");
+  const feedbackResp = await db.query("SELECT * FROM feedback");
+  res.render('admin', { title: 'Admin', meetings: meetingsResp.rows, officers: officersResp.rows, feedbackData: feedbackResp.rows });
+}));
 
-router.post('/admin', isAdminAuthenticated, upload('image'), async (req, res) => {
-  await db.query("INSERT INTO images VALUES ($1, $2)", [req.file.filename, req.body.caption]);
+router.post('/admin', isAdminAuthenticated, upload('image'), fallible(async (req, res) => {
+  const image = {}
+  if (req.file) {
+    image.id = req.file.filename;
+  } else {
+    throw new TypeError("Invalid image file");
+  }
+
+  if (typeof req.body.caption === "string" && req.body.caption.length > 0) {
+    image.caption = req.body.caption;
+  } else {
+    throw new TypeError("Invalid image caption");
+  }
+
+  await db.query("INSERT INTO images VALUES ($1, $2)", [image.id, image.caption]);
   req.flash('success', 'Successfully uploaded image!');
   res.redirect('/admin');
-});
+}));
 
-router.post('/officers', isAdminAuthenticated, async (req, res) => {
-  const resp = await db.query("SELECT 1 FROM users WHERE id = $1", [req.body.user_id]);
-  if(resp.rows.length > 0) {
-    await db.query("UPDATE users SET title = $1 WHERE id = $2", [req.body.title, req.body.user_id]);
-    req.flash('success', 'Successfully set officer role to ' + req.body.title + ' for ' + req.body.user_id + '.');
-    res.redirect('/admin');
+router.post('/officers', isAdminAuthenticated, fallible(async (req, res) => {
+  const user = {};
+  if (typeof req.body.user_id === "string" && req.body.user_id.length > 0) {
+    user.id = req.body.user_id;
+  } else {
+    throw new TypeError("Invalid user id");
   }
-  else {
+
+  if (typeof req.body.title === "string" && req.body.title.length > 0) {
+    user.title = req.body.title;
+  } else {
+    throw new TypeError("Invalid title");
+  }
+
+  const userResp = await db.query("SELECT 1 FROM users WHERE id = $1", [user.id]);
+  if (userResp.rows.length > 0) {
+    await db.query("UPDATE users SET title = $1 WHERE id = $2", [user.title, user.id]);
+    req.flash('success', 'Successfully set officer role to ' + user.title + ' for ' + user.id + '.');
+    res.redirect('/admin');
+  } else {
     req.flash('error', 'There is not a user to modify!');
     res.redirect('/admin');
   }
-});
+}));
 
-router.post('/officers/remove', isAdminAuthenticated, async (req, res) => {
-  await db.query("UPDATE users SET title = $1 WHERE id = $2", ['', req.body.user_id]);
-  req.flash('success', 'Successfully removed ' + req.body.user_id + ' as an officer.');
+router.post('/officers/remove', isAdminAuthenticated, fallible(async (req, res) => {
+  if (typeof req.body.user_id !== "string" || req.body.user_id.length < 0) {
+    throw new TypeError("Invalid user id")
+  }
+  const userId = req.body.user_id;
+
+  await db.query("UPDATE users SET title = $1 WHERE id = $2", ['', userId]);
+  req.flash('success', 'Successfully removed ' + userId + ' as an officer.');
   res.redirect('/admin');
-});
+}));
 
-router.post('/feedback/remove', isAdminAuthenticated, async (req, res) => {
-  await db.query("DELETE FROM feedback WHERE user_id = $1 and feedback = $2", [req.body.user_id, req.body.feedback]);
-  req.flash('success', 'Successfully removed feedback from ' + req.body.user_id + '.');
+router.post('/feedback/remove', isAdminAuthenticated, fallible(async (req, res) => {
+  const feedback = {};
+  if (typeof req.body.user_id === "string" && req.body.user_id.length > 0) {
+    feedback.user_id = req.body.user_id;
+  } else {
+    throw new TypeError("Invalid user id");
+  }
+
+  if (typeof req.body.feedback === "string" && req.body.feedback.length > 0) {
+    feedback.feedback = req.body.feedback;
+  } else {
+    throw new TypeError("Invalid title");
+  }
+
+  await db.query("DELETE FROM feedback WHERE user_id = $1 and feedback = $2", 
+    [feedback.user_id, feedback.feedback]);
+  req.flash('success', 'Successfully removed feedback from ' + feedback.user_id + '.');
   res.redirect('/admin');
-});
+}));
 
-router.post('/meetings', isAdminAuthenticated, async (req, res) => {
-  await db.query("INSERT INTO meetings VALUES ($1, $2, $3, $4, $5, $6, $7)", [
-    uuid.v4(), req.body.title, req.body.description, req.body.date,
+const parseMeetingInfo = (body) => {
+  const meeting = {};
+
+  if (typeof body.title === "string" && body.title.length > 0) {
+    meeting.title = body.title;
+  } else {
+    throw new TypeError("Invalid meeting title");
+  }
+
+  if (typeof body.description === "string" && body.description.length > 0) {
+    meeting.description = body.description;
+  } else {
+    throw new TypeError("Invalid meeting description");
+  }
+
+  // Ensure that the meeting date is actually a valid timestamp. Date only indicates this
+  // by having a NaN time (which is really hard to accurately check), or having a string
+  // representation of "Invalid date". Do the latter since it's less of a footgun.
+  if (typeof body.date === "string" && new Date(body.date).toString() !== "Invalid Date") {
+    meeting.date = body.date;
+  } else {
+    throw new TypeError("Invalid meeting date");
+  }
+
+  // parseInt returns NaN on invalid input, which should then fail the range comparison
+  // since any comparison w/NaN is false.
+  const duration = parseInt(body.duration);
+  if (duration >= 0 && body.duration <= 10) {
     // convert hours -> milliseconds
-    (req.body.duration * 60 * 60 * 1000), req.body.location, req.body.type]);
-  res.redirect('/admin');
-});
+    meeting.duration = body.duration * 60 * 60 * 1000;
+  } else {
+    throw new TypeError("Invalid meeting duration");
+  }
 
-router.post('/meetings/edit', isAdminAuthenticated, async (req, res) => {
-  await db.query("UPDATE meetings SET title = $1, description = $2, date = $3, duration = $4, location = $5, type = $6 WHERE id = $7", [
-    req.body.title, req.body.description, req.body.date,
-    // convert hours -> milliseconds
-    (req.body.duration * 60 * 60 * 1000), req.body.location, req.body.type, req.body.meeting_id]);
+  if (typeof body.location === "string" && body.location.length > 0) {
+    meeting.location = body.location;
+  } else {
+    throw new TypeError("Invalid meeting location");
+  }
+
+  if (typeof body.type === "string" && body.type.length > 0) {
+    meeting.type = body.type;
+  } else {
+    throw new TypeError("Invalid meeting type");
+  }
+
+  return meeting;
+}
+
+router.post('/meetings', isAdminAuthenticated, fallible(async (req, res) => {
+  const meeting = parseMeetingInfo(req.body);
+  meeting.id = uuid.v4();
+
+  await db.query(
+    "INSERT INTO meetings VALUES ($1, $2, $3, $4, $5, $6, $7)", 
+    [meeting.id, meeting.title, meeting.description, meeting.date,
+    meeting.duration, meeting.location, meeting.type]);
+
   res.redirect('/admin');
-});
+}));
+
+router.post('/meetings/edit', isAdminAuthenticated, fallible(async (req, res) => {
+  const meeting = parseMeetingInfo(req.body);
+  if (uuid.validate(req.body.meeting_id)) {
+    meeting.id = req.body.meeting_id;
+  } else {
+    throw new TypeError("Invalid meeting id");
+  }
+
+  await db.query(
+    "UPDATE meetings SET title = $1, description = $2, date = $3, duration = $4, location = $5, type = $6 WHERE id = $7",
+    [meeting.title, meeting.description, meeting.date, meeting.duration, meeting.location, meeting.type, meeting.id]);
+
+  res.redirect('/admin');
+}));
 
 module.exports = router;

--- a/routes/attendance.js
+++ b/routes/attendance.js
@@ -4,7 +4,7 @@ const db = require('../database/db');
 const uuid = require('uuid');
 const { fallible } = require("../middleware");
 
-const parseAttendanceForm = req => {
+const parseAttendanceForm = (req) => {
   let form = {};
 
   if (uuid.validate(req.body.meeting_id)) {
@@ -109,7 +109,7 @@ router.post('/attend', fallible(async (req, res) => {
       }
     }
 
-    await db.transaction(async client => {
+    await db.transaction(async (client) => {
       await client.query("INSERT INTO attendance VALUES ($1, $2, $3) ON CONFLICT DO NOTHING", 
         [form.meeting_id, form.user_id, form.user_name]);
       if (feedback) {

--- a/routes/attendance.js
+++ b/routes/attendance.js
@@ -1,108 +1,126 @@
 const express = require('express');
 const router = express.Router();
 const db = require('../database/db');
+const uuid = require('uuid');
+const { fallible } = require("../middleware");
 
-router.get('/rsvp', async (req, res) => {
-  // Find next meeting and show it to user
-  // TODO: This actually doesn't work
-  const meetingResp = await db.query("SELECT * FROM meetings ORDER BY date LIMIT 1");
-  if (meetingResp.rows.length > 0) {
-    let rsvped = false;
-    if (req.user) {
-      let rsvpResp = await db.query("SELECT * FROM rsvps WHERE user_id = $1", [req.user.id]);
-      rsvped = rsvpResp.rows.length > 0;
+const parseAttendanceForm = req => {
+  let form = {};
+
+  if (uuid.validate(req.body.meeting_id)) {
+    form.meeting_id = req.body.meeting_id;
+  } else {
+    throw new TypeError("Invalid meeting id");
+  }
+
+  if (req.user) {
+    // User is already logged in
+    form.user_id = req.user.id;
+    form.user_name = req.user.name;
+  } else {
+    // User is submitting w/form data
+    if (typeof req.body.user_id === "string" && req.body.user_id.length > 0) {
+      form.user_id = req.body.user_id;
+    } else {
+      throw new TypeError("Invalid user id");
     }
-    res.render('rsvp', { title: 'RSVP', meeting: meetingResp.rows[0], rsvped: rsvped });
-  }
-  else {
-    res.render('rsvp', { title: 'RSVP', meeting: false });
-  }
-});
 
-router.post('/rsvp', async (req, res) => {
-  // use logged in credentials if possible
-  let user_id;
-  let name;
-
-  if (req.body.user_id && req.body.name) {
-    // user is submitting with form data
-    user_id = req.body.user_id;
-    name = req.body.name;
-  }
-  else {
-    user_id = req.user.id;
-    name = req.user.name;
+    if (typeof req.body.name === "string" && req.body.name.length > 0) {
+      form.user_name = req.body.name;
+    } else {
+      throw new TypeError("Invalid user name");
+    }
   }
 
-  // If id or name is still null, something went very wrong
-  if (!user_id || !name) {
-    req.flash('error', 'Something went wrong when trying to track your RSVP! Please contact a site administrator.');
-    res.redirect('/');
+  return form;
+}
+
+router.get('/rsvp', fallible(async (req, res) => {
+  // Find next meeting and show it to user
+  const meetingResp = await db.query(
+    "SELECT * FROM meetings WHERE date >= NOW() ORDER BY date LIMIT 1");
+  const meeting = meetingResp.rows[0];
+
+  let rsvped = false;
+  if (meeting && req.user) {    
+    let rsvpResp = await db.query(
+      "SELECT * FROM rsvps WHERE meeting = $1 AND user_id = $2", 
+      [meeting.id, req.user.id]);
+    rsvped = rsvpResp.rows.length > 0;
   }
 
+  res.render('rsvp', { title: 'RSVP', meeting: meeting, rsvped: rsvped });
+}));
+
+router.post('/rsvp', fallible(async (req, res) => {
+  const form = parseAttendanceForm(req);
   // Check if user has RSVP'ed already
-  const rsvp = await db.query("SELECT 1 FROM rsvps WHERE user_id = $1 AND meeting = $2", [user_id, req.body.meeting_id]);
-  if (rsvp.rows.length > 0) {
+  const rsvpResp = await db.query(
+    "SELECT 1 FROM rsvps WHERE user_id = $1 AND meeting = $2", 
+    [form.user_id, form.meeting_id]);
+
+  if (rsvpResp.rows.length > 0) {
     req.flash('error', 'You have already RSVP\'ed for this event!');
     res.redirect('/');
-  }
-  else {
-    await db.query("INSERT INTO rsvps VALUES ($1, $2, $3)", [req.body.meeting_id, user_id, name]);
+  } else {
+    await db.query(
+      "INSERT INTO rsvps VALUES ($1, $2, $3)", 
+      [form.meeting_id, form.user_id, form.user_name]);
+
     req.flash('success', 'Successfully RSVP\'ed! Thanks for coming.');
     res.redirect('/');
   }
-});
+}));
 
-router.get('/attend', async (req, res) => {
+router.get('/attend', fallible(async (req, res) => {
   // Find active meeting if possible (2 hour buffer) TODO there's probably a better way to do this
-  const meetingResp = await db.query("SELECT * FROM meetings WHERE date >= NOW() - INTERVAL '2 hours' and date <= NOW() + INTERVAL '2 hours'");
-  if (meetingResp.rows.length > 0) {
-    let rsvped = false;
-    if (req.user) {
-      const rsvpResp = await db.query("SELECT * FROM attendance WHERE user_id = $1 AND meeting = $2", [req.user.id, meetingResp.rows[0].id]);
-      rsvped = rsvpResp.rows.length > 0;
-    }
-    res.render('attend', { title: 'Attend', meeting: meetingResp.rows[0], rsvped: rsvped });
-  }
-  else {
-    res.render('attend', { title: 'Attend', meeting: false });
-  }
-});
+  const meetingResp = await db.query(
+    "SELECT * FROM meetings WHERE date >= NOW() - INTERVAL '2 hours' and date <= NOW() + INTERVAL '2 hours'");
+  const meeting = meetingResp.rows[0];
+  let rsvped = false;
 
-router.post('/attend', async (req, res) => {
-  // use logged in credentials if possible
-  let user_id;
-  let name;
-
-  if (req.body.user_id && req.body.name) {
-    // user is submitting with form data
-    user_id = req.body.user_id;
-    name = req.body.name;
-  }
-  else {
-    user_id = req.user.id;
-    name = req.user.name;
+  if (meeting && req.user) {
+    const rsvpResp = await db.query(
+      "SELECT * FROM attendance WHERE user_id = $1 AND meeting = $2", 
+      [req.user.id, meeting.id]);
+    rsvped = rsvpResp.rows.length > 0;
   }
 
-  // If id or name is still null, something went very wrong
-  if (!user_id || !name) {
-    req.flash('error', 'Something went wrong when trying to track your RSVP! Please contact a site administrator.');
-    res.redirect('/');
-  }
+  res.render('attend', { title: 'Attend', meeting: meeting, rsvped: rsvped });
+}));
 
+router.post('/attend', fallible(async (req, res) => {
+  const form = parseAttendanceForm(req);
   // Check if submitted already
-  const attendance = await db.query("SELECT * FROM attendance WHERE user_id = $1 AND meeting = $2", [user_id, req.body.meeting_id]);
-  if (attendance.rows.length > 0) {
+  const attendanceResp = await db.query(
+    "SELECT * FROM attendance WHERE user_id = $1 AND meeting = $2",
+    [form.user_id, form.meeting_id]);
+  
+  if (attendanceResp.rows.length > 0) {
     req.flash('error', 'You have already submitted an attendance form for this event!');
     res.redirect('/');
   } else {
+    let feedback;
     if (req.body.feedback) {
-      await db.query("INSERT INTO feedback VALUES ($1, $2)", [user_id, req.body.feedback]);
+      if (typeof req.body.feedback === "string" && req.body.feedback.length > 0) {
+        feedback = req.body.feedback;
+      } else {
+        throw new TypeError("Invalid attendance feedback");
+      }
     }
-    await db.query("INSERT INTO attendance VALUES ($1, $2, $3) ON CONFLICT DO NOTHING", [req.body.meeting_id, user_id, name]);
+
+    await db.transaction(async client => {
+      await client.query("INSERT INTO attendance VALUES ($1, $2, $3) ON CONFLICT DO NOTHING", 
+        [form.meeting_id, form.user_id, form.user_name]);
+      if (feedback) {
+        await client.query("INSERT INTO feedback VALUES ($1, $2)", 
+          [form.user_id, feedback]);
+      }
+    });
+
     req.flash('success', 'Your attendance has been logged! Thanks for coming.')
     res.redirect('/');
   }
-});
+}));
 
 module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,13 +1,12 @@
 const passport = require('passport');
 const express = require('express');
 const router = express.Router();
-const { fallible } = require('../middleware')
 
-router.get('/login', passport.authenticate('google', { scope: ['email', 'profile'] }), fallible(async (req, res) => {
+router.get('/login', passport.authenticate('google', { scope: ['email', 'profile'] }), async (req, res) => {
   res.redirect('/');
-}));
+});
 
-router.get('/logout', fallible(async (req, res) => {
+router.get('/logout', async (req, res) => {
   req.logout((err) => {
     if (err) {
       req.flash('error', 'Could not successfully log out! Please contact a site administrator.')
@@ -18,11 +17,11 @@ router.get('/logout', fallible(async (req, res) => {
       res.redirect('/');
     }
   });
-}));
+});
 
-router.get('/auth/google/callback', passport.authenticate('google', { failureRedirect: '/', keepSessionInfo: true }), fallible(async (req, res) => {
+router.get('/auth/google/callback', passport.authenticate('google', { failureRedirect: '/', keepSessionInfo: true }), async (req, res) => {
   res.redirect(req.session.returnTo || '/');
   delete req.session.returnTo;
-}));
+});
 
 module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,12 +1,13 @@
 const passport = require('passport');
 const express = require('express');
 const router = express.Router();
+const { fallible } = require('../middleware')
 
-router.get('/login', passport.authenticate('google', { scope: ['email', 'profile'] }), (req, res) => {
+router.get('/login', passport.authenticate('google', { scope: ['email', 'profile'] }), fallible(async (req, res) => {
   res.redirect('/');
-});
+}));
 
-router.get('/logout', (req, res) => {
+router.get('/logout', fallible(async (req, res) => {
   req.logout((err) => {
     if (err) {
       req.flash('error', 'Could not successfully log out! Please contact a site administrator.')
@@ -17,11 +18,11 @@ router.get('/logout', (req, res) => {
       res.redirect('/');
     }
   });
-});
+}));
 
-router.get('/auth/google/callback', passport.authenticate('google', { failureRedirect: '/', keepSessionInfo: true }), (req, res) => {
+router.get('/auth/google/callback', passport.authenticate('google', { failureRedirect: '/', keepSessionInfo: true }), fallible(async (req, res) => {
   res.redirect(req.session.returnTo || '/');
   delete req.session.returnTo;
-});
+}));
 
 module.exports = router;

--- a/routes/presentations.js
+++ b/routes/presentations.js
@@ -1,36 +1,87 @@
 const express = require('express');
 const uuid = require('uuid');
 const db = require('../database/db');
+const { fallible } = require("../middleware");
 const router = express.Router();
 
-router.get('/presentations', async (req, res) => {
-  const resp = await db.query("SELECT * FROM presentations ORDER BY date DESC");
-  for (presentation of resp.rows) {
+router.get('/presentations', fallible(async (req, res) => {
+  const presentationsResp = await db.query("SELECT * FROM presentations ORDER BY date DESC");
+  for (presentation of presentationsResp.rows) {
     // Just cleave off the time value randomly added for no reason
     // by JS Date, not bringing in Moment.js for just this.
     presentation.date = presentation.date.toISOString().split("T")[0];
   }
-  res.render('presentations', { title: 'Presentations', presentations: resp.rows });
-});
+  res.render('presentations', { title: 'Presentations', presentations: presentationsResp.rows });
+}));
 
-router.post('/presentations', async (req, res) => {
+const parsePresentationId = (body) => {
+  if (!uuid.validate(body.presentation_id)) {
+    throw new TypeError("Invalid presentation id");
+  }
+  
+  return body.presentation_id;
+}
+
+const parsePresentationInfo = (body) => {
+  const presentation = {};
+
+  if (typeof body.title === "string" && body.title.length > 0) {
+    presentation.title = body.title;
+  } else {
+    throw new TypeError("Invalid presentation title");
+  }
+
+  if (typeof body.description === "string" && body.description.length > 0) {
+    presentation.description = body.description;
+  } else {
+    throw new TypeError("Invalid presentation description");
+  }
+
+  if (typeof body.date === "string" && new Date(body.date).toString() !== "Invalid Date") {
+    presentation.date = body.date;
+  } else {
+    throw new TypeError("Invalid presentation date");
+  }
+
+  if (typeof body.url === "string" && body.url.length > 0) {
+    presentation.url = body.url;
+  } else {
+    throw new TypeError("Invalid presentation url");
+  }
+
+  return presentation;
+}
+
+router.post('/presentations', fallible(async (req, res) => {
+  const presentation = parsePresentationInfo(req.body);
+  presentation.id = uuid.v4();
+
   await db.query("INSERT INTO presentations VALUES ($1, $2, $3, $4, $5)", 
-    [uuid.v4(), req.body.title, req.body.description, req.body.date, req.body.url]);
-  req.flash('success', 'Successfully added project!');
+    [presentation.id, presentation.title, presentation.description,
+      presentation.date, presentation.url]);
+  
+  req.flash('success', 'Successfully added presentation!');
   res.redirect('/presentations');
-});
+}));
 
-router.post('/presentations/edit', async (req, res) => {
+router.post('/presentations/edit', fallible(async (req, res) => {
+  const presentation = parsePresentationInfo(req.body);
+  presentation.id = parsePresentationId(req.body);
+
   await db.query("UPDATE presentations SET title = $1, description = $2, date = $3, url = $4 WHERE id = $5", 
-    [req.body.title, req.body.description, req.body.date, req.body.url, req.body.presentation_id]);
-  req.flash('success', 'Successfully edited project!');
-  res.redirect('/presentations');
-});
+    [presentation.title, presentation.description, presentation.date, presentation.url, presentation.id]);
 
-router.post('/presentations/delete', async (req, res) => {
-  await db.query("DELETE FROM presentations WHERE id = $1", [req.body.presentation_id]);
-  req.flash('success', 'Successfully deleted project!');
+  req.flash('success', 'Successfully edited presentation!');
   res.redirect('/presentations');
-});
+}));
+
+router.post('/presentations/delete', fallible(async (req, res) => {
+  const presentationId = parsePresentationId(req.body);
+
+  await db.query("DELETE FROM presentations WHERE id = $1", [presentationId]);
+
+  req.flash('success', 'Successfully deleted presentation!');
+  res.redirect('/presentations');
+}));
 
 module.exports = router;

--- a/routes/presentations.js
+++ b/routes/presentations.js
@@ -4,16 +4,6 @@ const db = require('../database/db');
 const { fallible } = require("../middleware");
 const router = express.Router();
 
-router.get('/presentations', fallible(async (req, res) => {
-  const presentationsResp = await db.query("SELECT * FROM presentations ORDER BY date DESC");
-  for (presentation of presentationsResp.rows) {
-    // Just cleave off the time value randomly added for no reason
-    // by JS Date, not bringing in Moment.js for just this.
-    presentation.date = presentation.date.toISOString().split("T")[0];
-  }
-  res.render('presentations', { title: 'Presentations', presentations: presentationsResp.rows });
-}));
-
 const parsePresentationId = (body) => {
   if (!uuid.validate(body.presentation_id)) {
     throw new TypeError("Invalid presentation id");
@@ -51,6 +41,16 @@ const parsePresentationInfo = (body) => {
 
   return presentation;
 }
+
+router.get('/presentations', fallible(async (req, res) => {
+  const presentationsResp = await db.query("SELECT * FROM presentations ORDER BY date DESC");
+  for (presentation of presentationsResp.rows) {
+    // Just cleave off the time value randomly added for no reason
+    // by JS Date, not bringing in Moment.js for just this.
+    presentation.date = presentation.date.toISOString().split("T")[0];
+  }
+  res.render('presentations', { title: 'Presentations', presentations: presentationsResp.rows });
+}));
 
 router.post('/presentations', fallible(async (req, res) => {
   const presentation = parsePresentationInfo(req.body);

--- a/routes/presentations.js
+++ b/routes/presentations.js
@@ -27,12 +27,16 @@ const parsePresentationInfo = (body) => {
     throw new TypeError("Invalid presentation description");
   }
 
+  // Ensure the presentation's date resolves to a valid timestamp. Date only indicates this
+  // by having a NaN time (which is really hard to accurately check), or having a string
+  // representation of "Invalid date". Do the latter since it's less of a footgun.
   if (typeof body.date === "string" && new Date(body.date).toString() !== "Invalid Date") {
     presentation.date = body.date;
   } else {
     throw new TypeError("Invalid presentation date");
   }
 
+  // TODO: We should probably also be validating URLs and the like
   if (typeof body.url === "string" && body.url.length > 0) {
     presentation.url = body.url;
   } else {

--- a/routes/presentations.js
+++ b/routes/presentations.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const uuid = require('uuid');
 const db = require('../database/db');
+const { URL } = require('url');
 const { fallible } = require("../middleware");
 const router = express.Router();
 
@@ -36,12 +37,13 @@ const parsePresentationInfo = (body) => {
     throw new TypeError("Invalid presentation date");
   }
 
-  // TODO: We should probably also be validating URLs and the like
-  if (typeof body.url === "string" && body.url.length > 0) {
-    presentation.url = body.url;
-  } else {
-    throw new TypeError("Invalid presentation url");
+  // URL will throw a TypeError if invalid, hence why this statement is free-floating.
+  try {
+    new URL(body.url);
+  } catch (e) {
+    throw TypeError("Invalid presentation url");
   }
+  presentation.url = body.url;
 
   return presentation;
 }

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const fs = require('fs/promises');
+const fs = require('fs');
 const db = require('../database/db');
 const { isLoggedIn, upload, fallible } = require('../middleware');
 const router = express.Router();
@@ -34,7 +34,7 @@ router.post('/profile/avatar', isLoggedIn, upload('avatar'), fallible(async (req
 
   if (req.user.avatar_id) {
     // Free the space taken up by the now-unused profile picture
-    await fs.unlink("uploads/" + req.user.avatar_id);
+    fs.unlinkSync("uploads/" + req.user.avatar_id);
   }
   await db.query("UPDATE users SET avatar_id = $1 WHERE id = $2", [avatarId, req.user.id]);
 

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -1,39 +1,56 @@
 const express = require('express');
-const fs = require('fs');
+const fs = require('fs/promises');
 const db = require('../database/db');
-const { isLoggedIn, upload } = require('../middleware');
+const { isLoggedIn, upload, fallible } = require('../middleware');
 const router = express.Router();
 
-router.get('/profile/:id', async (req, res) => {
-  const targetEmail = req.params.id;
-  const resp = await db.query("SELECT * FROM users WHERE id = $1", [targetEmail]);
+router.get('/profile/:id', fallible(async (req, res) => {
+  const userResp = await db.query("SELECT * FROM users WHERE id = $1", [req.params.id]);
+  const targetUser = userResp.rows[0];
   
-  if(resp.rows.length > 0) {
-    const meetingsResp = await db.query("SELECT title, date FROM meetings JOIN attendance ON meetings.id = attendance.meeting WHERE attendance.user_id = $1", [targetEmail]);
-    const projectsResp = await db.query("SELECT title, repository FROM projects JOIN project_authors ON project_authors.project_id = projects.id WHERE project_authors.author_id = $1", [targetEmail]);
-    const isUser = req.user ? (targetEmail == req.user.id) : false;
-    res.render('profile', { title: resp.rows[0].name, profileUser: resp.rows[0], isProfileUser: isUser, meetings: meetingsResp.rows, projects: projectsResp.rows });
-  }
-  else {
+  if (targetUser) {
+    const meetingsResp = await db.query(
+      "SELECT title, date FROM meetings JOIN attendance ON meetings.id = attendance.meeting WHERE attendance.user_id = $1", 
+      [targetUser.id]);
+
+    const projectsResp = await db.query(
+      "SELECT title, repository FROM projects JOIN project_authors ON project_authors.project_id = projects.id WHERE project_authors.author_id = $1",
+      [targetUser.id]);
+
+    const isUser = req.user && targetUser.id == req.user.id;
+    res.render('profile', { 
+      title: targetUser.name, profileUser: targetUser, isProfileUser: isUser, 
+      meetings: meetingsResp.rows, projects: projectsResp.rows });
+  } else {
     res.status(404).render('404', { title: '404' });
   }
-});
+}));
 
-router.post('/profile', isLoggedIn, upload('avatar'), async (req, res) => {
-  await db.query("UPDATE users SET avatar_id = $1 WHERE id = $2", [req.file.filename, req.user.id]);
+router.post('/profile/avatar', isLoggedIn, upload('avatar'), fallible(async (req, res) => {
+  if (!req.file) {
+    throw new TypeError("Invalid user avatar");
+  }
+  const avatarId = req.file.filename;
+
   if (req.user.avatar_id) {
     // Free the space taken up by the now-unused profile picture
-    fs.unlinkSync("uploads/" + req.user.avatar_id);
+    await fs.unlink("uploads/" + req.user.avatar_id);
   }
+  await db.query("UPDATE users SET avatar_id = $1 WHERE id = $2", [avatarId, req.user.id]);
+
   req.flash('success', 'Profile picture uploaded successfully!');
   res.redirect('/profile/' + req.user.id);
-});
+}));
 
-router.post('/profile/about', isLoggedIn, async (req, res) => {
-  req.user.about = req.body.about;
-  await db.query("UPDATE users SET about = $1 WHERE id = $2", [req.body.about, req.user.id]);
+router.post('/profile/about', isLoggedIn, fallible(async (req, res) => {
+  if (!req.body.about) {
+    throw new TypeError("Invalid user about")
+  }
+  const about = req.body.about;
+
+  await db.query("UPDATE users SET about = $1 WHERE id = $2", [about, req.user.id]);
   req.flash('success', 'Biography updated successfully!');
   res.redirect('/profile/' + req.user.id);
-});
+}));
 
 module.exports = router;

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -43,7 +43,7 @@ router.post('/profile/avatar', isLoggedIn, upload('avatar'), fallible(async (req
 }));
 
 router.post('/profile/about', isLoggedIn, fallible(async (req, res) => {
-  if (!req.body.about) {
+  if (typeof req.body.about !== "string" || req.body.about.length < 1) {
     throw new TypeError("Invalid user about")
   }
   const about = req.body.about;

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -25,14 +25,9 @@ const parseBaseProjectForm = async (req) => {
     throw new TypeError("Invalid project repository");
   }
 
+  // Website field is optional and will be an empty string if not specified.
   if (typeof req.body.website === "string") {
-    // Website field is optional and will be undefined if not specified,
-    // transform into an empty string is that's the case.
-    if (req.body.website) {
-      project.website = req.body.website;
-    } else {
-      project.website = "";
-    }
+    project.website = req.body.website;
   } else {
     throw new TypeError("Invalid project website");
   }

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -1,125 +1,169 @@
 const express = require('express');
 const db = require('../database/db');
-const fs = require('fs');
+const fs = require('fs/promises');
 const uuid = require('uuid');
-const { isAdminAuthenticated, upload } = require('../middleware');
+const { isAdminAuthenticated, upload, fallible } = require('../middleware');
 const router = express.Router();
 
-// Methods to help parse project queries
-
-const parseAuthors = async (req, res) => {
-  const getAuthorValue = (i) => req.body[`author${i}`]
-  req.body.authors = [];
-  for (let i = 0; getAuthorValue(i); ++i) {
-    const author = getAuthorValue(i);
-    const resp = await db.query("SELECT FROM users WHERE id = $1", [author]);
-    if (resp.rows.length == 0) {
-      req.flash('error', 'Project authors must have created an account prior!');
-      return false;
-    }
-    req.body.authors.push(author);
-  }
-  return true;
-}
-
-const transformProjectRequest = async (req, res, next) => {
-  let response = await parseAuthors(req, res);
-  if (!response) {
-    // Multer needs to be ran first to parse the request, but that will also
-    // lead to an upload sticking around even if an error occurs. Make sure
-    // that this upload is removed.
-    if (req.file) {
-      fs.unlinkSync("uploads/" + req.file.filename);
-    }
-    res.redirect('/projects');
-  }
-  else {
-    // Website field is optional and will be undefined if not specified,
-    // transform into an empty string is that's the case.
-    if (!req.body.website) {
-      req.body.website = ""
-    }
-  
-    // Archived field will either be "on" if selected or undefined if not,
-    // convert it to a boolean by those rules.
-    req.body.archived = (req.body.archived !== undefined);
-    next();
-  }
-}
-
-const clearProjectImage = async (req) => {
-  // We don't have access to the image id from the request usually, query it from the db.
-  const resp = await db.query("SELECT image_id FROM projects WHERE id = $1", [req.body.project_id]);
-  fs.unlinkSync("uploads/" + resp.rows[0].image_id);
-}
-
-router.get('/projects', async (req, res) => {
-  const projectResp = await db.query("SELECT * FROM projects ORDER BY archived, title");
+router.get('/projects', fallible(async (req, res) => {
+  const projectsResp = await db.query("SELECT * FROM projects ORDER BY archived, title");
   for (let project of projectResp.rows) {
-    const authorResp = await db.query("SELECT users.id, users.name, users.avatar_id " +
+    const authorsResp = await db.query("SELECT users.id, users.name, users.avatar_id " +
       "FROM users JOIN project_authors ON users.id = project_authors.author_id " +
       "JOIN projects ON project_authors.project_id = projects.id " +
       "WHERE projects.id = $1", [project.id]);
-    project.authors = authorResp.rows;
+    project.authors = authorsResp.rows;
   }
-  res.render('projects', { title: "Projects", projects: projectResp.rows });
-});
+  res.render('projects', { title: "Projects", projects: projectsResp.rows });
+}));
 
-router.post('/projects', isAdminAuthenticated, upload('image'), transformProjectRequest, async (req, res) => {
-  const id = uuid.v4();
-  await db.query(
-    "INSERT INTO projects VALUES ($1, $2, $3, $4, $5, $6, $7)",
-    [id, req.body.title, req.body.description, req.body.website, req.body.repository,
-      req.body.archived, req.file.filename]);
-
-  // Insert the author relations from the query. These were already validated to
-  // be present in the users DB earlier, so they can be inserted directly.
-  for (let i = 0; i < req.body.authors.length; ++i) {
-    await db.query(
-      "INSERT INTO project_authors VALUES ($1, $2)", [id, req.body.authors[i]])
+const parseBaseProjectForm = async (req) => {
+  const project = {};
+  if (typeof req.body.title === "string" && req.body.title.length > 0) {
+    project.title = req.body.title;
+  } else {
+    throw new TypeError("Invalid project title");
   }
+
+  if (typeof req.body.description === "string" && req.body.description.length > 0) {
+    project.description = req.body.description;
+  } else {
+    throw new TypeError("Invalid project description");
+  }
+
+  if (typeof req.body.repository === "string" && req.body.repository.length > 0) {
+    project.repository = req.body.repository;
+  } else {
+    throw new TypeError("Invalid project repository");
+  }
+
+  if (typeof req.body.website === "string") {
+    // Website field is optional and will be undefined if not specified,
+    // transform into an empty string is that's the case.
+    if (req.body.website) {
+      project.website = req.body.website;
+    } else {
+      project.website = "";
+    }
+  } else {
+    throw new TypeError("Invalid project website");
+  }
+
+  const getAuthorValue = (i) => req.body[`author${i}`]
+  project.authors = [];
+  for (let i = 0; getAuthorValue(i); ++i) {
+    const author = getAuthorValue(i);
+    const authorResp = await db.query("SELECT FROM users WHERE id = $1", [author]);
+    if (authorResp.rows.length == 0) {
+      req.flash('error', `Author ${author} was not found!`);
+      return;
+    }
+    project.authors.push(author);
+  }
+
+  if (project.authors.length < 1) {
+    throw TypeError("Invalid project authors")
+  }
+
+  // Archived field will either be "on" if selected or undefined if not,
+  // convert it to a boolean by those rules.
+  project.archived = (req.body.archived !== undefined);
+
+  if (req.file) {
+    project.imageId = req.file.filename;
+  }
+
+  return project;  
+}
+
+const withProjectForm = (body) => 
+  fallible(
+    async (req, res) => {  
+      const project = await parseBaseProjectForm(req);
+      if (project) {
+        await body(req, res, project);
+      } else if (req.file) {
+        await fs.unlink(req.file.filename);
+      }
+      res.redirect('/projects')
+    }
+  )
+
+router.post('/projects', isAdminAuthenticated, upload('image'), withProjectForm(async (req, res, project) => {
+  project.id = uuid.v4();
+  if (!project.imageId) {
+    throw new TypeError("Invalid project image id");
+  }
+
+  await db.transaction(async (client) => {
+    await client.query(
+      "INSERT INTO projects VALUES ($1, $2, $3, $4, $5, $6, $7)",
+      [project.id, project.title, project.description, project.website, 
+        project.repository, project.archived, project.imageId]);
+    // Insert the author relations from the query. These were already validated to
+    // be present in the users DB earlier, so they can be inserted directly.
+    for (let author of project.authors) {
+      await client.query(
+        "INSERT INTO project_authors VALUES ($1, $2)", [project.id, author])
+    }
+  })
 
   req.flash('success', 'Successfully added project!');
-  res.redirect('/projects');
-});
+}));
 
-router.post('/projects/edit', isAdminAuthenticated, upload('image', true), transformProjectRequest, async (req, res) => {
-  // Image uploading is optional when editing projects, so we need to perform different queries
-  // for the different states.
-  if (req.file) {
-    // Free the space taken up by the now-unused project image.
-    await clearProjectImage(req);
-    await db.query(
-      "UPDATE projects SET title = $1, description = $2, website = $3, repository = $4, archived = $5, image_id = $6 WHERE id = $7",
-      [req.body.title, req.body.description, req.body.website, req.body.repository,
-      req.body.archived, req.file.filename, req.body.project_id])
+router.post('/projects/edit', isAdminAuthenticated, upload('image', true), withProjectForm(async (req, res, project) => {
+  if (!uuid.validate(req.body.project_id)) {
+    throw new Error("Invalid project id")
+  }
+  project.id = req.body.project_id;
+
+  // Image uploading is optional when editing projects, so we will need to determine whether we
+  // need to remove an old image or retain the existing image. Either way, this requires us to
+  // obtain the image ID from the database first.
+  const imageResp = await db.query("SELECT image_id FROM projects WHERE id = $1", [project.id]);
+  const imageId = imageResp.rows[0].image_id;
+  if (project.imageId) {
+    // New image is being applied, remove the old image.
+    await fs.unlink("uploads/" + imageId);
   } else {
-    // No image specified, leave it unchanged and only commit the rest.
-    await db.query(
-      "UPDATE projects SET title = $1, description = $2, website = $3, repository = $4, archived = $5 WHERE id = $6",
-      [req.body.title, req.body.description, req.body.website, req.body.repository,
-      req.body.archived, req.body.project_id])
+    // No change in image.
+    project.imageId = imageId;
   }
 
-  // Since the author amount could have changed in length, just wipe the prior relations
-  // and insert ones to avoid stray entries.
-  await db.query("DELETE FROM project_authors WHERE project_id = $1", [req.body.project_id]);
-  for (let i = 0; i < req.body.authors.length; ++i) {
-    await db.query(
-      "INSERT INTO project_authors VALUES ($1, $2)", [req.body.project_id, req.body.authors[i]])
-  }
+  await db.transaction(async (client) => {
+    await client.query(
+      "UPDATE projects SET title = $1, description = $2, website = $3, repository = $4, archived = $5, image_id = $6 WHERE id = $7",
+      [project.title, project.description, project.website, project.repository, project.archived, project.imageId, project.id])
+    
+    // Since the author amount could have changed in length, just wipe the prior relations
+    // and insert ones to avoid stray entries.
+    await client.query("DELETE FROM project_authors WHERE project_id = $1", [project.id]);
+    for (let author of project.authors) {
+      await client.query(
+        "INSERT INTO project_authors VALUES ($1, $2)", [project.id, author])
+    }
+  });
 
   req.flash('success', 'Successfully edited project!');
-  res.redirect('/projects');
-});
+}));
 
-router.post('/projects/delete', isAdminAuthenticated, async (req, res) => {
-  // Free the space taken up by the now-unused project image.
-  await clearProjectImage(req);
-  await db.query("DELETE FROM project_authors WHERE project_id = $1", [req.body.project_id]);
-  await db.query("DELETE FROM projects WHERE id = $1", [req.body.project_id]);
+router.post('/projects/delete', isAdminAuthenticated, fallible(async (req, res) => {
+  if (!uuid.validate(req.body.project_id)) {
+    throw new Error("Invalid project id")
+  }
+  const projectId = req.body.project_id;
+  
+  // Free the space taken up by the now-unused image.
+  const imageResp = await db.query("SELECT image_id FROM projects WHERE id = $1", [projectId]);
+  fs.unlink("uploads/" + imageResp.rows[0].image_id);
+
+  await db.transaction(async (client) => {  
+    await client.query("DELETE FROM project_authors WHERE project_id = $1", [projectId]);
+    await client.query("DELETE FROM projects WHERE id = $1", [projectId]);
+  });
+
   req.flash('success', 'Successfully deleted project!');
   res.redirect('/projects');
-});
+}));
 
 module.exports = router;

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -111,7 +111,7 @@ router.post('/projects', isAdminAuthenticated, upload('image'), withProjectForm(
   req.flash('success', 'Successfully added project!');
 }));
 
-router.post('/projects/edit', isAdminAuthenticated, upload('image', true), withProjectForm(async (req, res, project) => {
+router.post('/projects/edit', isAdminAuthenticated, upload('image'), withProjectForm(async (req, res, project) => {
   if (!uuid.validate(req.body.project_id)) {
     throw new Error("Invalid project id")
   }

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -76,7 +76,7 @@
                 <h5 class="modal-title" id="pfp-modal-label">Change Avatar</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <form method="POST" action="/profile" enctype="multipart/form-data">
+            <form method="POST" action="/profile/avatar" enctype="multipart/form-data">
                 <div class="modal-body">
                     <% if (profileUser.avatar_id) { %>
                         <img class="profile-picture" src="/uploads/<%= profileUser.avatar_id %>" />
@@ -102,7 +102,7 @@
     <div class="modal-dialog modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
-            <h5 class="modal-title" id="meetings-modal-label"><%= user.name %>'s Attended Meetings %></h5>
+            <h5 class="modal-title" id="meetings-modal-label"><%= profileUser.name %>'s Attended Meetings %></h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
@@ -149,8 +149,8 @@
             </div>
             <form method="POST" action="/profile" enctype="multipart/form-data">
                 <div class="modal-body">
-                    <% if (user.avatar_id) { %>
-                        <img class="profile-picture" src="uploads/<%= user.avatar_id %>" />
+                    <% if (profileUser.avatar_id) { %>
+                        <img class="profile-picture" src="uploads/<%= profileUser.avatar_id %>" />
                     <% } else { %>
                         <img class="profile-picture" src="static/images/default_user.png" />
                     <% } %>                             

--- a/views/rsvp.ejs
+++ b/views/rsvp.ejs
@@ -37,7 +37,7 @@
                             <span class="input-group-text" id="email-addon">@mines.edu</span>
                         </div>
 
-                        <button class="btn d-inline-block btn-success">RSVP</button>
+                        <button class="btn d-inline-block btn-primary">RSVP</button>
                     </form>
                 <% } %>
             <% } %>


### PR DESCRIPTION
This PR attempts to reduce corner cases that would result in a complete crash of the server, or at least major state issues.

- All routes are now wrapped in a new "fallible" middleware that just invokes the body in a try-catch. This should make any error in a route go directly to the 500 page.
- Any DB writes that occur in succession now use transactions using a new `db.transaction` helper function.
- Any incoming forms are validated manually to present malicious actors from forging invalid requests that could lead to a bad DB state or crash. This includes the format of parameters too, such as dates or URLs.
- As I went along, I also fixed some weird for-in loops and made database response variables use consistent naming.