### PR TITLE
Fix attendance DB field naming

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,7 +105,7 @@ app.get('/', fallible(async (req, res) => {
   let meetingsResp = await db.query("SELECT * FROM meetings WHERE date >= NOW() AND date <= NOW() + INTERVAL '2 weeks' ORDER BY date DESC LIMIT 2");
   for (let meeting of meetingsResp.rows) {
     if (req.user) {
-      const rsvpResp = await db.query("SELECT * FROM rsvps WHERE user_id = $1 AND meeting = $2", [req.user.id, meeting.id]);
+      const rsvpResp = await db.query("SELECT * FROM rsvps WHERE user_id = $1 AND meeting_id = $2", [req.user.id, meeting.id]);
       meeting.rsvped = rsvpResp.rows.length > 0;
     } else {
       meeting.rsvped = false;

--- a/database/init_database.sql
+++ b/database/init_database.sql
@@ -41,17 +41,17 @@ CREATE TABLE IF NOT EXISTS feedback (
 );
 
 CREATE TABLE IF NOT EXISTS attendance (
-    "meeting"  TEXT REFERENCES meetings(id),
-    "user_id"  TEXT NOT NULL,
-    "name"     TEXT NOT NULL,
-    PRIMARY KEY ("meeting", "user_id")
+    "meeting_id"  TEXT REFERENCES meetings(id),
+    "user_id"     TEXT NOT NULL,
+    "user_name"   TEXT NOT NULL,
+    PRIMARY KEY ("meeting_id", "user_id")
 );
 
 CREATE TABLE IF NOT EXISTS rsvps (
-    "meeting"  TEXT REFERENCES meetings(id),
-    "user_id"  TEXT NOT NULL,
-    "name"     TEXT NOT NULL,
-    PRIMARY KEY ("meeting", "user_id")
+    "meeting_id" TEXT REFERENCES meetings(id),
+    "user_id"    TEXT NOT NULL,
+    "user_name"  TEXT NOT NULL,
+    PRIMARY KEY ("meeting_id", "user_id")
 );
 
 CREATE TABLE IF NOT EXISTS images (

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -8,7 +8,7 @@ router.get('/admin', isAdminAuthenticated, fallible(async (req, res) => {
   let meetingsResp = await db.query("SELECT * FROM meetings ORDER BY date");
   for (let meeting of meetingsResp.rows) {
     const attendanceResp = await db.query(
-      "SELECT attendance.user_id FROM meetings JOIN attendance ON meetings.id = attendance.meeting WHERE meetings.id = $1", 
+      "SELECT attendance.user_id FROM meetings JOIN attendance ON meetings.id = attendance.meeting_id WHERE meetings.id = $1", 
       [meeting.id]);
     meeting.attendance = attendanceResp.rows;
   }

--- a/routes/attendance.js
+++ b/routes/attendance.js
@@ -44,7 +44,7 @@ router.get('/rsvp', fallible(async (req, res) => {
   let rsvped = false;
   if (meeting && req.user) {    
     let rsvpResp = await db.query(
-      "SELECT * FROM rsvps WHERE meeting = $1 AND user_id = $2", 
+      "SELECT * FROM rsvps WHERE meeting_id = $1 AND user_id = $2", 
       [meeting.id, req.user.id]);
     rsvped = rsvpResp.rows.length > 0;
   }
@@ -56,7 +56,7 @@ router.post('/rsvp', fallible(async (req, res) => {
   const form = parseAttendanceForm(req);
   // Check if user has RSVP'ed already
   const rsvpResp = await db.query(
-    "SELECT 1 FROM rsvps WHERE user_id = $1 AND meeting = $2", 
+    "SELECT 1 FROM rsvps WHERE user_id = $1 AND meeting_id = $2", 
     [form.user_id, form.meeting_id]);
 
   if (rsvpResp.rows.length > 0) {
@@ -81,7 +81,7 @@ router.get('/attend', fallible(async (req, res) => {
 
   if (meeting && req.user) {
     const rsvpResp = await db.query(
-      "SELECT * FROM attendance WHERE user_id = $1 AND meeting = $2", 
+      "SELECT * FROM attendance WHERE user_id = $1 AND meeting_id = $2", 
       [req.user.id, meeting.id]);
     rsvped = rsvpResp.rows.length > 0;
   }
@@ -93,7 +93,7 @@ router.post('/attend', fallible(async (req, res) => {
   const form = parseAttendanceForm(req);
   // Check if submitted already
   const attendanceResp = await db.query(
-    "SELECT * FROM attendance WHERE user_id = $1 AND meeting = $2",
+    "SELECT * FROM attendance WHERE user_id = $1 AND meeting_id = $2",
     [form.user_id, form.meeting_id]);
   
   if (attendanceResp.rows.length > 0) {

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -10,7 +10,7 @@ router.get('/profile/:id', fallible(async (req, res) => {
   
   if (targetUser) {
     const meetingsResp = await db.query(
-      "SELECT title, date FROM meetings JOIN attendance ON meetings.id = attendance.meeting WHERE attendance.user_id = $1", 
+      "SELECT title, date FROM meetings JOIN attendance ON meetings.id = attendance.meeting_id WHERE attendance.user_id = $1", 
       [targetUser.id]);
 
     const projectsResp = await db.query(

--- a/routes/schedule.js
+++ b/routes/schedule.js
@@ -8,7 +8,7 @@ router.get('/schedule', fallible(async (req, res) => {
   let upcomingResp = await db.query("SELECT * FROM meetings WHERE date >= NOW() AND date <= NOW() + INTERVAL '3 weeks' ORDER BY date");
   for (let meeting of upcomingResp.rows) {
     if (req.user) {
-      const rsvpResp = await db.query("SELECT * FROM rsvps WHERE user_id = $1 AND meeting = $2", [req.user.id, meeting.id]);
+      const rsvpResp = await db.query("SELECT * FROM rsvps WHERE user_id = $1 AND meeting_id = $2", [req.user.id, meeting.id]);
       meeting.rsvped = rsvpResp.rows.length > 0;
     } else {
       meeting.rsvped = false;


### PR DESCRIPTION
Other database tables clarify user and meeting references instead of using ambiguous "meeting" or "name" values. Switch to those in the `attendance` & `rsvps` tables.