### PR TITLE
Only show error stack trace in debug mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,7 +136,14 @@ app.use((req, res, next) => {
 });
 
 app.use((err, req, res, next) => {
-  res.status(500).render('error', { title: "Error", error: err });
+  let error;
+  if (process.env.NODE_ENV === "development") {
+    // Possible security hazard if we expose the trace, so only display it
+    // in development mode.
+    error = err.stack;
+  }
+
+  res.status(500).render('error', { title: "Error", error: error });
 });
 
 app.listen(process.env.PORT || 3000, async () => {

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -4,10 +4,12 @@
 	<div class="container">
 		<div class="large-card shadow">		
 			<h1>Internal Server Error</h1>
-			<p>Sorry - Something broke on our end!</p>
+			<p>Sorry - Something broke on our end! If the issue persists, please contact us.</p>
 
-			<p>Stacktrace:</p>
-			<textarea style="width: 100%; height: 50vh"><%= error %></textarea>
+			<% if (error) { %>
+				<p>Stacktrace:</p>
+				<textarea style="width: 100%; height: 50vh"><%= error %></textarea>
+			<% } %>
 		</div>
 	</div>
 </main>


### PR DESCRIPTION
This PR makes it so that the 500 page only shows the stack trace of the error when `NODE_ENV == development`. This preserves security in production while making it easier to debug in the backend.